### PR TITLE
chore(readme): add CI badges and ACP disambiguation note

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@
 
 ![ACP Inspector overview](docs/assets/acp-inspector-overview.jpg)
 
-> **Note:** This project targets [Zed's Agent Client Protocol](https://agentclientprotocol.com/) — the JSON-RPC 2.0 standard for IDE↔AI-agent integration backed by Zed, JetBrains, Google, GitHub, and Anthropic. It is **not** related to IBM's now-archived "Agent Communication Protocol" (also abbreviated ACP).
+> [!NOTE]
+> This project targets [Zed's Agent Client Protocol](https://agentclientprotocol.com/) — the JSON-RPC 2.0 standard for IDE↔AI-agent integration backed by Zed Industries and JetBrains. It is **not** related to IBM's now-archived "Agent Communication Protocol" (also abbreviated ACP).
 
 ACP Inspector is an F# implementation of the Agent Client Protocol (ACP) plus a validation / sentinel layer.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # ACP Inspector
 
+[![CI](https://github.com/venikman/ACP-inspector/actions/workflows/ci.yml/badge.svg)](https://github.com/venikman/ACP-inspector/actions/workflows/ci.yml)
+[![.NET 10](https://img.shields.io/badge/.NET-10.0-512BD4)](https://dotnet.microsoft.com/)
+[![F#](https://img.shields.io/badge/F%23-378BBA)](https://fsharp.org/)
+
 ![ACP Inspector overview](docs/assets/acp-inspector-overview.jpg)
+
+> **Note:** This project targets [Zed's Agent Client Protocol](https://agentclientprotocol.com/) — the JSON-RPC 2.0 standard for IDE↔AI-agent integration backed by Zed, JetBrains, Google, GitHub, and Anthropic. It is **not** related to IBM's now-archived "Agent Communication Protocol" (also abbreviated ACP).
 
 ACP Inspector is an F# implementation of the Agent Client Protocol (ACP) plus a validation / sentinel layer.
 


### PR DESCRIPTION
## Summary

- Add CI status, .NET 10, and F# badges to README header
- Add blockquote disambiguating Zed's Agent Client Protocol from IBM's archived protocol of the same acronym

Part of a Tier 1 hygiene sweep. Companion metadata changes already applied directly via gh repo edit (no code diff):

- 18 GitHub topics (replacing the single "active" topic)
- Homepage URL set to docs/index.md
- Repo description rewritten to lead with the value proposition instead of the architecture

## Test plan

- [x] markdownlint-cli2 passes locally on README.md (0 errors)
- [ ] CI passes (markdownlint + lychee link check + fantomas + tests + coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/venikman/acp-inspector/pull/39" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added CI and framework compatibility badges indicating build status and support for .NET 10 and F#.
  * Added a highlighted note clarifying the project targets Zed’s Agent Client Protocol (JSON‑RPC 2.0) and is not related to other projects using the same ACP acronym.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->