### PR TITLE
fix(sentinel): warn when additionalDirectories is supplied without the advertised capability

### DIFF
--- a/sentinel/src/Acp.Validation.fs
+++ b/sentinel/src/Acp.Validation.fs
@@ -519,6 +519,32 @@ module Validation =
             trace.messages
             |> List.iteri (fun idx msg ->
                 match msg with
+                | Message.FromClient(ClientToAgentMessage.SessionNew p) ->
+                    if
+                        not (List.isEmpty p.additionalDirectories)
+                        && caps.sessionCapabilities.additionalDirectories.IsNone
+                    then
+                        addFinding
+                            idx
+                            Lane.Session
+                            Severity.Warning
+                            "ACP.SESSION.CAPABILITY_NOT_ADVERTISED"
+                            "session/new supplied additionalDirectories but the agent did not advertise sessionCapabilities.additionalDirectories."
+                            None
+
+                | Message.FromClient(ClientToAgentMessage.SessionLoad p) ->
+                    if
+                        not (List.isEmpty p.additionalDirectories)
+                        && caps.sessionCapabilities.additionalDirectories.IsNone
+                    then
+                        addFinding
+                            idx
+                            Lane.Session
+                            Severity.Warning
+                            "ACP.SESSION.CAPABILITY_NOT_ADVERTISED"
+                            "session/load supplied additionalDirectories but the agent did not advertise sessionCapabilities.additionalDirectories."
+                            (Some p.sessionId)
+
                 | Message.FromClient(ClientToAgentMessage.SessionResume p) ->
                     if caps.sessionCapabilities.resume.IsNone then
                         addFinding
@@ -527,6 +553,18 @@ module Validation =
                             Severity.Warning
                             "ACP.SESSION.CAPABILITY_NOT_ADVERTISED"
                             "session/resume was called but the agent did not advertise sessionCapabilities.resume."
+                            (Some p.sessionId)
+
+                    if
+                        not (List.isEmpty p.additionalDirectories)
+                        && caps.sessionCapabilities.additionalDirectories.IsNone
+                    then
+                        addFinding
+                            idx
+                            Lane.Session
+                            Severity.Warning
+                            "ACP.SESSION.CAPABILITY_NOT_ADVERTISED"
+                            "session/resume supplied additionalDirectories but the agent did not advertise sessionCapabilities.additionalDirectories."
                             (Some p.sessionId)
 
                 | Message.FromClient(ClientToAgentMessage.SessionClose p) ->

--- a/sentinel/tests/Acp.Validation.Tests.fs
+++ b/sentinel/tests/Acp.Validation.Tests.fs
@@ -972,3 +972,129 @@ module ValidationTests =
             | Some failure -> Assert.Contains("logout", failure.message)
             | None -> failwith "expected ValidationFailure"
         | many -> failwithf "expected exactly one ACP.AUTH.CAPABILITY_NOT_ADVERTISED finding, got %d" many.Length
+
+    let private additionalDirectoriesFindings (findings: ValidationFinding list) =
+        findings
+        |> List.filter (fun f ->
+            match f.failure with
+            | Some failure ->
+                failure.code = "ACP.SESSION.CAPABILITY_NOT_ADVERTISED"
+                && failure.message.Contains "additionalDirectories"
+            | None -> false)
+
+    [<Fact>]
+    let ``additionalDirectories without advertised capability yields ACP.SESSION.CAPABILITY_NOT_ADVERTISED warning``
+        ()
+        =
+        // Default initResult advertises resume/close/delete but NOT
+        // sessionCapabilities.additionalDirectories.
+        let sid = SessionId "s-adddirs-no-cap"
+
+        let methods: (string * ClientToAgentMessage) list =
+            [ "session/new",
+              ClientToAgentMessage.SessionNew
+                  { cwd = "."
+                    mcpServers = []
+                    additionalDirectories = [ "/extra" ] }
+              "session/load",
+              ClientToAgentMessage.SessionLoad
+                  { sessionId = sid
+                    cwd = "."
+                    mcpServers = []
+                    additionalDirectories = [ "/extra" ] }
+              "session/resume",
+              ClientToAgentMessage.SessionResume
+                  { sessionId = sid
+                    cwd = "."
+                    mcpServers = []
+                    additionalDirectories = [ "/extra" ]
+                    _meta = None } ]
+
+        for (methodName, request) in methods do
+            let trace: Message list =
+                [ Message.FromClient(ClientToAgentMessage.Initialize initParams)
+                  Message.FromAgent(AgentToClientMessage.InitializeResult initResult)
+                  Message.FromClient request ]
+
+            let result = runWithValidation sid spec trace false None None
+
+            match additionalDirectoriesFindings result.findings with
+            | [ f ] ->
+                Assert.Equal(Severity.Warning, f.severity)
+
+                match f.failure with
+                | Some failure -> Assert.Contains(methodName, failure.message)
+                | None -> failwith "expected ValidationFailure"
+            | many ->
+                failwithf
+                    "expected exactly one additionalDirectories capability finding for %s, got %d"
+                    methodName
+                    many.Length
+
+    [<Fact>]
+    let ``additionalDirectories with advertised capability yields no capability warning`` () =
+        let sid = SessionId "s-adddirs-cap"
+
+        let advertisingInitResult: InitializeResult =
+            { initResult with
+                agentCapabilities =
+                    { agentCaps with
+                        sessionCapabilities =
+                            { agentCaps.sessionCapabilities with
+                                additionalDirectories = Some { _meta = None } } } }
+
+        let trace: Message list =
+            [ Message.FromClient(ClientToAgentMessage.Initialize initParams)
+              Message.FromAgent(AgentToClientMessage.InitializeResult advertisingInitResult)
+              Message.FromClient(
+                  ClientToAgentMessage.SessionNew
+                      { cwd = "."
+                        mcpServers = []
+                        additionalDirectories = [ "/extra" ] }
+              )
+              Message.FromClient(
+                  ClientToAgentMessage.SessionResume
+                      { sessionId = sid
+                        cwd = "."
+                        mcpServers = []
+                        additionalDirectories = [ "/extra" ]
+                        _meta = None }
+              ) ]
+
+        let result = runWithValidation sid spec trace false None None
+
+        Assert.True(
+            additionalDirectoriesFindings result.findings |> List.isEmpty,
+            "expected no additionalDirectories capability finding when the capability is advertised"
+        )
+
+    [<Fact>]
+    let ``empty additionalDirectories yields no capability warning`` () =
+        // Empty list == omitted per the A7 schema note; must not warn even when
+        // the capability is not advertised.
+        let sid = SessionId "s-adddirs-empty"
+
+        let trace: Message list =
+            [ Message.FromClient(ClientToAgentMessage.Initialize initParams)
+              Message.FromAgent(AgentToClientMessage.InitializeResult initResult)
+              Message.FromClient(
+                  ClientToAgentMessage.SessionNew
+                      { cwd = "."
+                        mcpServers = []
+                        additionalDirectories = [] }
+              )
+              Message.FromClient(
+                  ClientToAgentMessage.SessionResume
+                      { sessionId = sid
+                        cwd = "."
+                        mcpServers = []
+                        additionalDirectories = []
+                        _meta = None }
+              ) ]
+
+        let result = runWithValidation sid spec trace false None None
+
+        Assert.True(
+            additionalDirectoriesFindings result.findings |> List.isEmpty,
+            "expected no additionalDirectories capability finding for empty additionalDirectories"
+        )


### PR DESCRIPTION
## Summary
- Cherry-pick of `f850ca9`, which was pushed to the PR #42 branch (addressing codex review comment 3383841811) but missed the merge: #42 was merged from a checkout at `34242da`, one commit behind the branch head, so the fix never landed on master.
- `checkCapabilityGatedRequests` gated `session/resume`/`close`/`delete`/`logout` but never looked at `sessionCapabilities.additionalDirectories`. Per design section A7, supplying non-empty `additionalDirectories` on `session/new`, `session/load`, or `session/resume` against an agent that did not advertise the capability now yields an `ACP.SESSION.CAPABILITY_NOT_ADVERTISED` warning; an empty list equals omitted and never warns.

## Test Plan
- [x] New tests: per-method warning (new/load/resume), advertised-capability guard, empty-list guard — written first and watched fail ("got 0 findings") before the check existed
- [x] `dotnet test sentinel/tests/ACP.Tests.fsproj -c Release` — 437 passed, 0 failed on this branch
- [x] `dotnet fantomas ... --check` — clean (verified on the original commit; cherry-pick is byte-identical)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/venikman/acp-inspector/pull/46" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->